### PR TITLE
Add macbook pro 13 2020 m1 with xcode 13.1 on monterey benchmark

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -16,6 +16,7 @@ If a device you are looking for is not on the list below, check out open [issues
 |        Device        |           CPU           | RAM | SSD | HDD | Xcode |  macOS  | Time(sec) |
 |:--------------------:|:-----------------------:|:---:|:---:|:---:|:-----:|:-------:|:---------:|
 | MacBook Pro 14" 2021 |   Apple M1 Pro 8-core   |  16 | 512 |     |  13.1 | 12.0.1  |    109    |
+| MacBook Pro 13" 2020 |      Apple M1 8-core    |  16 | 1TB |     |  13.1 | 12.0.1  |    130    |
 | MacBook Pro 16 2019  |    i7 2.6 GHz 6-core    |  32 | 512 |     |  13.0 | 11.6    |    248    |
 
 


### PR DESCRIPTION
## Checklist

**If you have any non-Apple hardware components - submit your results to the `Custom Hardware` table.**

* [X] I performed [all steps](https://github.com/devMEremenko/XcodeBenchmark#before-each-test) to correctly run XcodeBenchmark.
* [X] I used Xcode 12.5 or above.
* [X] I attached a screenshot with a compilation time and other fields, [example](img/contribution-example.png).
* [X] I confirm that `Time` column is still sorted.
* [X] The content in cells is centered.

![XcodeBench macbook13-m1-13 1](https://user-images.githubusercontent.com/1105089/138861422-d34a3fa0-91d3-4e9c-b401-c77ea44c22ed.png)

