### PR TITLE
Add GPU Cores to the report

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -13,18 +13,18 @@ If a device you are looking for is not on the list below, check out open [issues
 
 ## Xcode 13.0 or above
 
-|        Device        |           CPU           | RAM | SSD | HDD | Xcode |  macOS  | Time(sec) |
-|:--------------------:|:-----------------------:|:---:|:---:|:---:|:-----:|:-------:|:---------:|
-| MacBook Pro 16" 2021 |      M1 Max 10-core     |  32 | 1TB |     |  13.1 | 12.0.1  |    98     |
-| MacBook Pro 16" 2021 |      M1 Pro 10-core     |  16 | 1TB |     |  13.1 | 12.0.1  |    102    |
-| MacBook Pro 14" 2021 |      M1 Pro 8-core      |  16 | 512 |     |  13.1 | 12.0.1  |    109    |
-| MacBook Pro 13" 2020 |      M1 8-core          |  16 | 1TB |     |  13.1 | 12.0.1  |    130    |
-|    iMac 24" 2021     |      M1 8-core          |  16 | 512 |     |  13.1 | 12.0.1  |    130    |
-| MacBook Pro 16" 2019 |    i9 2.4 GHz 8-core    |  32 | 1TB |     |  13.0 | 11.6    |    223    |
-|     Mac mini 2018    |    i5 3.0 Ghz 6-core    |   8 | 256 |     |  13.0 | 12.0.1  |    235    |
-| MacBook Pro 16" 2019 |    i7 2.6 GHz 6-core    |  32 | 512 |     |  13.0 | 11.6    |    248    |
-| MacBook Pro 15" 2018 |    i9 2.9 GHz 6-core    |  32 | 1TB |     |  13.0 | 11.6    |    263    |
-| MacBook Pro 13" 2018 |    i7 2.7 GHz 4-core    |   8 | 256 |     |  13.0 | 11.6    |    336    |
+|        Device        |           CPU           |   GPU    | RAM | SSD | HDD | Xcode |  macOS  | Time(sec) |
+|:--------------------:|:-----------------------:|:--------:|:---:|:---:|:---:|:-----:|:-------:|:---------:|
+| MacBook Pro 16" 2021 |      M1 Max 10-core     |          |  32 | 1TB |     |  13.1 | 12.0.1  |    98     |
+| MacBook Pro 16" 2021 |      M1 Pro 10-core     |          |  16 | 1TB |     |  13.1 | 12.0.1  |    102    |
+| MacBook Pro 14" 2021 |      M1 Pro 8-core      |          |  16 | 512 |     |  13.1 | 12.0.1  |    109    |
+| MacBook Pro 13" 2020 |      M1 8-core          |          |  16 | 1TB |     |  13.1 | 12.0.1  |    130    |
+|    iMac 24" 2021     |      M1 8-core          |  8-core  |  16 | 512 |     |  13.1 | 12.0.1  |    130    |
+| MacBook Pro 16" 2019 |    i9 2.4 GHz 8-core    |          |  32 | 1TB |     |  13.0 | 11.6    |    223    |
+|     Mac mini 2018    |    i5 3.0 Ghz 6-core    |          |   8 | 256 |     |  13.0 | 12.0.1  |    235    |
+| MacBook Pro 16" 2019 |    i7 2.6 GHz 6-core    |          |  32 | 512 |     |  13.0 | 11.6    |    248    |
+| MacBook Pro 15" 2018 |    i9 2.9 GHz 6-core    |          |  32 | 1TB |     |  13.0 | 11.6    |    263    |
+| MacBook Pro 13" 2018 |    i7 2.7 GHz 4-core    |          |   8 | 256 |     |  13.0 | 11.6    |    336    |
 
 ## Xcode 12.5
 

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -31,6 +31,8 @@ if [ -n "$PATH_TO_PROJECT" ]; then
 	system_profiler SPHardwareDataType | grep "Processor Speed:"
 	system_profiler SPHardwareDataType | grep "Total Number of Cores:"
 
+ 	system_profiler SPDisplaysDataType | grep "Total Number of Cores:" | sed 's/Total Number of Cores:/GPU Cores:/'
+
 	system_profiler SPHardwareDataType | grep "L2 Cache (per Core):"
 	system_profiler SPHardwareDataType | grep "L3 Cache:"
 


### PR DESCRIPTION
With the new M1 Pro and Max, it is important to log the number of GPU cores as well to have a better picture. This PR adds "GPU Cores" to the final report as on the screenshot.

<img width="802" alt="Screenshot 2021-10-27 at 14 32 44" src="https://user-images.githubusercontent.com/59749/139076308-1e6e05e2-43a5-428c-ad0b-017c42e51439.png">