### PR TITLE
Macbook Air 13" M2 8GB 256GB 2022, Xcode 16.4, Tahoe 26.1, Build [288 sec]

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -59,6 +59,7 @@ _XcodeBenchmark has been updated to support Xcode 16.3, and new submissions must
 | MacBook Air 13" 2024 |      M3 8-core          | 16  | 256 | 16.2  |   14.6   |    184    |
 | MacBook Air 13" 2022 |      M2 8-core          | 16  | 512 | 16.1  |   15.1   |    202    |
 | MacBook Air 13" 2020 |      M1 8c (7c GPU)     |  8  | 256 | 16.2  |   15.3.2 |    242    |
+| MacBook Air 13" 2024 |      M3 8-core          | 16  | 512 | 16.4  |   26.2   |    247    |
 | MacBook Pro 13" 2020 |      M1 8c (8c GPU)     | 16  | 256 | 16.1  |   15.1   |    258    |
 | MacBook Air 13" 2022 |      M2 8c (8c GPU)     | 8   | 256 | 16.4  |   26.1   |    288    |
 | iMac19,2 21.5" 2019  |      i7 3.2 GHz         | 16  | 512 | 16.2  |   14.7.5 |    349    |

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -17,6 +17,7 @@ If a device you are looking for is not listed below, check out open [issues](htt
 | Macbook Pro 16" 2024 |      M2 Pro 12c         | 16  | 1TB | 26.1  |  26.1    |    158    |
 | Mac Mini 2023        |      M2 Pro 10c         | 16  | 512 | 26.1  |  26.1    |    185    |
 | Macbook Air 13" 2024 |      M4 10c (10c GPU)   | 16  | 256 | 26.1  |  26.1    |    188    | 
+| Macbook Air 13" 2024 |      M3 8 core          | 16  | 512 | 26.2  |  26.2    |    240    | 
 
 
 ## Xcode 16 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -60,6 +60,7 @@ _XcodeBenchmark has been updated to support Xcode 16.3, and new submissions must
 | MacBook Air 13" 2022 |      M2 8-core          | 16  | 512 | 16.1  |   15.1   |    202    |
 | MacBook Air 13" 2020 |      M1 8c (7c GPU)     |  8  | 256 | 16.2  |   15.3.2 |    242    |
 | MacBook Pro 13" 2020 |      M1 8c (8c GPU)     | 16  | 256 | 16.1  |   15.1   |    258    |
+| MacBook Air 13" 2022 |      M2 8c (8c GPU)     | 8   | 256 | 16.4  |   26.1   |    288    |
 | iMac19,2 21.5" 2019  |      i7 3.2 GHz         | 16  | 512 | 16.2  |   14.7.5 |    349    |
 | Mac Mini 2018        |      i7 3.2 GHz         | 64  | 512 | 16.1  |   15.1   |    490    |
 | MacBook Pro 15" 2014 |      i7 2.8 GHz 4-core  | 16  | 1TB | 16.4  |   15.6   |    1003   |


### PR DESCRIPTION


<img width="729" height="347" alt="521401031-d5c4dbec-6ec2-4124-bfec-01312a56a192" src="https://github.com/user-attachments/assets/634112b4-e5b1-4041-bf02-45aeb6a3921d" />


Adding Macbook Air 13" M2 8/256 from 2022 testing 2025

## Checklist

**If you have any non-Apple hardware components - submit your results to the `Custom Hardware` table.**

* [x] I performed [all steps](https://github.com/devMEremenko/XcodeBenchmark#before-each-test) to correctly run XcodeBenchmark.
* [x] I used Xcode 15.0 or above.
* [x] I attached a screenshot with a compilation time and other fields, [example](img/contribution-example.png).
* [x] I confirm that `Time` column is still sorted.
* [x] The content in cells is centered.