### PR TITLE
Add Mac Mini 2024 M4 Pro Xcode 26.4 result

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -21,6 +21,7 @@ If a device you are looking for is not listed below, check out open [issues](htt
 | MacBook Pro 14" 2024 |      M4 Pro 14c         | 48  | 1TB | 26.3  |  26.3.1  |    108    |
 | Mac Studio 2022      |      M1 Ultra 20-core   | 128 | 1TB | 26.1.1|  26.1    |    112    |
 | Macbook Pro 14" 2025 |      M5 10-core         | 16  | 512 | 26.3  |  26.3.1  |    146    |
+| Mac Mini 2024        |      M4 Pro 14-core     | 64  | 4TB | 26.4  |  26.3.1  |    146    |
 | MacBook Pro 14" 2024 |      M4 Pro 12c         | 24  | 512 | 26.3  |  26.3    |    164    |
 | Macbook Air 13" 2026 |      M5 10c (10c GPU)   | 32  | 512 | 26.3  |  26.3.1  |    173    |
 | Macbook Air 13" 2024 |      M4 10c (10c GPU)   | 16  | 256 | 26.1  |  26.1    |    188    |


### PR DESCRIPTION
## Checklist

* [x] I performed [all steps](https://github.com/devMEremenko/XcodeBenchmark#before-each-test) to correctly run XcodeBenchmark.
* [x] I used Xcode 26.4.
* [x] I attached a screenshot with a compilation time and other fields.
* [x] I confirm that `Time` column is still sorted.
* [x] The content in cells is centered.

## Result

- Device: Mac Mini 2024
- CPU: Apple M4 Pro 14-core
- RAM: 64 GB
- SSD: 4 TB
- Xcode: 26.4
- macOS: 26.3.1
- Time: 146.377 sec

Depends on #650 because Xcode 26.4 currently needs that compatibility fix to complete the benchmark build.

![Benchmark screenshot](https://raw.githubusercontent.com/sunimp/XcodeBenchmark/sun-pr-assets/.github/pr-assets/xcodebenchmark-result-mac-mini-m4-pro-xcode-26_4.png)
