### PR TITLE
Add M3 Ultra Xcode 26.4 benchmark result

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -14,6 +14,7 @@ If a device you are looking for is not listed below, check out open [issues](htt
 |        Device        |           CPU           | RAM | SSD | Xcode |   macOS  | Time(sec) |
 |:--------------------:|:-----------------------:|:---:|:---:|:-----:|:--------:|:---------:|
 | MacBook Pro 16" 2026 |      M5 Max 18-core     | 48  | 2TB | 26.3  |  26.4    |    84     |
+| Mac Studio 2025      |      M3 Ultra 28-core   | 96  | 1TB | 26.4  |  26.4.1  |    86     |
 | MacBook Pro 16" 2026 |      M5 Pro 18-core     | 48  | 1TB | 26.3  |  26.3    |    89     |
 | MacBook Pro 16" 2024 |      M4 Max 16-core     | 48  | 1TB | 26.3  |  26.2    |    89     |
 | Mac Studio 2023      |      M2 Ultra 24-core   | 64  | 2TB | 26.2  |  26.2    |    93     |


### PR DESCRIPTION
## Summary

Adds a 2025 Mac Studio result to the Xcode 26 table: M3 Ultra 28-core, 96 GB RAM, 1 TB SSD, Xcode 26.4, and macOS 26.4.1. The table records the build as 86 seconds.

## Screenshot

The benchmark result is 86.498 seconds.

<img width="900" alt="XcodeBenchmark result for the M3 Ultra Mac Studio" src="https://github.com/user-attachments/assets/ed382e75-19d8-48e8-8424-eaded655ccce" />
